### PR TITLE
cm1106 zero calibration bug fix

### DIFF
--- a/CM1106_CO2_Sensor/cm1106.h
+++ b/CM1106_CO2_Sensor/cm1106.h
@@ -10,10 +10,10 @@ class CM1106 : public UARTDevice {
     void setCo2CalibValue(uint16_t ppm = 400) {
         uint8_t cmd[6];
         memcpy(cmd, CM1106_CMD_SET_CO2_CALIB, sizeof(cmd));
-        CM1106_CMD_SET_CO2_CALIB[3] = ppm >> 8;
-        CM1106_CMD_SET_CO2_CALIB[4] = ppm & 0xFF;
+        cmd[3] = ppm >> 8;
+        cmd[4] = ppm & 0xFF;
         uint8_t response[4] = {0};
-        bool success = sendUartCommand(CM1106_CMD_SET_CO2_CALIB, sizeof(CM1106_CMD_SET_CO2_CALIB), response, sizeof(response));
+        bool success = sendUartCommand(cmd, sizeof(cmd), response, sizeof(response));
 
         if(!success) {
             ESP_LOGW(TAG, "Reading data from CM1106 failed!");

--- a/CM1106_CO2_Sensor/cm1106.h
+++ b/CM1106_CO2_Sensor/cm1106.h
@@ -10,8 +10,8 @@ class CM1106 : public UARTDevice {
     void setCo2CalibValue(uint16_t ppm = 400) {
         uint8_t cmd[6];
         memcpy(cmd, CM1106_CMD_SET_CO2_CALIB, sizeof(cmd));
-        cmd[3] = ppm >> 8;
-        cmd[4] = ppm & 0xFF;
+        CM1106_CMD_SET_CO2_CALIB[3] = ppm >> 8;
+        CM1106_CMD_SET_CO2_CALIB[4] = ppm & 0xFF;
         uint8_t response[4] = {0};
         bool success = sendUartCommand(CM1106_CMD_SET_CO2_CALIB, sizeof(CM1106_CMD_SET_CO2_CALIB), response, sizeof(response));
 


### PR DESCRIPTION
400ppm value is written to variable cmd instead of CM1106_CMD_SET_CO2_CALIB so the calibration is to 0ppm instead of 400ppm

I hope this is the proper way to make a pull request. Thank you!